### PR TITLE
Fixed infinite init loop

### DIFF
--- a/source/NodeInput.m
+++ b/source/NodeInput.m
@@ -31,8 +31,10 @@
 - (instancetype)initWithKey:(NSString *)key
                  validation:(nullable BOOL (^)(id _Nullable))validationBlock
                        node:(nullable id<NodeInputDelegate, Node>)node {
-    self = [self initWithKey:key node:node];
+    self = [super init];
     if (self) {
+        _key = key;
+        _node = node;
         _validationBlock = validationBlock;
     }
     return self;


### PR DESCRIPTION
When initializing a node input that subclasses NodeInput and implements initWithKey: node:, and calls initWithKey:validation:node, you would enter an infinite loop.