### PR TITLE
Add swift target

### DIFF
--- a/NodeGraph.xcodeproj/project.pbxproj
+++ b/NodeGraph.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		40101E72232A51F100D6EC69 /* NodeOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40101E71232A51F100D6EC69 /* NodeOutput.swift */; };
 		40101E74232B90E800D6EC69 /* NodeOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40101E73232B90E800D6EC69 /* NodeOutputTests.swift */; };
 		40101E78232B91DE00D6EC69 /* NodeGraphSwift_iosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404974502327717D00B04589 /* NodeGraphSwift_iosTests.swift */; };
-		40101E7A232B932F00D6EC69 /* module.modulemap in Sources */ = {isa = PBXBuildFile; fileRef = 40101E79232B932F00D6EC69 /* module.modulemap */; };
 		4049744C2327717D00B04589 /* NodeGraphSwift_ios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 404974432327717D00B04589 /* NodeGraphSwift_ios.framework */; };
 		404974532327717D00B04589 /* NodeGraphSwift_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = 404974452327717D00B04589 /* NodeGraphSwift_ios.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4049745D2327720000B04589 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4049745C2327720000B04589 /* Node.swift */; };
@@ -674,7 +673,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				40101E70232A51CD00D6EC69 /* NodeInput.swift in Sources */,
-				40101E7A232B932F00D6EC69 /* module.modulemap in Sources */,
 				4049745D2327720000B04589 /* Node.swift in Sources */,
 				40101E72232A51F100D6EC69 /* NodeOutput.swift in Sources */,
 			);

--- a/NodeGraph.xcodeproj/project.pbxproj
+++ b/NodeGraph.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		40101E70232A51CD00D6EC69 /* NodeInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40101E6F232A51CD00D6EC69 /* NodeInput.swift */; };
+		40101E72232A51F100D6EC69 /* NodeOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40101E71232A51F100D6EC69 /* NodeOutput.swift */; };
+		40101E74232B90E800D6EC69 /* NodeOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40101E73232B90E800D6EC69 /* NodeOutputTests.swift */; };
+		40101E78232B91DE00D6EC69 /* NodeGraphSwift_iosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404974502327717D00B04589 /* NodeGraphSwift_iosTests.swift */; };
+		40101E7A232B932F00D6EC69 /* module.modulemap in Sources */ = {isa = PBXBuildFile; fileRef = 40101E79232B932F00D6EC69 /* module.modulemap */; };
+		4049744C2327717D00B04589 /* NodeGraphSwift_ios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 404974432327717D00B04589 /* NodeGraphSwift_ios.framework */; };
+		404974532327717D00B04589 /* NodeGraphSwift_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = 404974452327717D00B04589 /* NodeGraphSwift_ios.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4049745D2327720000B04589 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4049745C2327720000B04589 /* Node.swift */; };
 		405038F221FC814A005B1585 /* NodeGraph.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 405038E821FC814A005B1585 /* NodeGraph.framework */; };
 		405038F721FC814A005B1585 /* NodeOutputTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 405038F621FC814A005B1585 /* NodeOutputTests.m */; };
 		405038F921FC814A005B1585 /* NodeGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 405038EB21FC814A005B1585 /* NodeGraph.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -18,6 +26,8 @@
 		4050396421FC896E005B1585 /* Node.m in Sources */ = {isa = PBXBuildFile; fileRef = 4050396221FC896E005B1585 /* Node.m */; };
 		4050396721FC89C7005B1585 /* RGBNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 4050396521FC89C7005B1585 /* RGBNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4050396821FC89C7005B1585 /* RGBNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 4050396621FC89C7005B1585 /* RGBNode.m */; };
+		408EC85F232BA3A900185B35 /* NodeInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408EC85E232BA3A900185B35 /* NodeInputTests.swift */; };
+		408EC861232BEDC200185B35 /* AbstractNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408EC860232BEDC200185B35 /* AbstractNodeTests.swift */; };
 		40C08F652210C34500FD01AE /* NodeGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 40C08F632210C34500FD01AE /* NodeGraph.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40C08F6E2210C5FD00FD01AE /* Node.m in Sources */ = {isa = PBXBuildFile; fileRef = 4050396221FC896E005B1585 /* Node.m */; };
 		40C08F6F2210C60100FD01AE /* NodeInput.m in Sources */ = {isa = PBXBuildFile; fileRef = 4050395A21FC8869005B1585 /* NodeInput.m */; };
@@ -55,6 +65,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		4049744D2327717D00B04589 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 405038DF21FC814A005B1585 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 404974422327717D00B04589;
+			remoteInfo = "NodeGraphSwift-ios";
+		};
 		405038F321FC814A005B1585 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 405038DF21FC814A005B1585 /* Project object */;
@@ -65,6 +82,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		40101E6F232A51CD00D6EC69 /* NodeInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeInput.swift; sourceTree = "<group>"; };
+		40101E71232A51F100D6EC69 /* NodeOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeOutput.swift; sourceTree = "<group>"; };
+		40101E73232B90E800D6EC69 /* NodeOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeOutputTests.swift; sourceTree = "<group>"; };
+		40101E79232B932F00D6EC69 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		404974432327717D00B04589 /* NodeGraphSwift_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NodeGraphSwift_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		404974452327717D00B04589 /* NodeGraphSwift_ios.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NodeGraphSwift_ios.h; sourceTree = "<group>"; };
+		404974462327717D00B04589 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4049744B2327717D00B04589 /* NodeGraphSwift-iosTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "NodeGraphSwift-iosTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		404974502327717D00B04589 /* NodeGraphSwift_iosTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeGraphSwift_iosTests.swift; sourceTree = "<group>"; };
+		404974522327717D00B04589 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4049745C2327720000B04589 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		405038E821FC814A005B1585 /* NodeGraph.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NodeGraph.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		405038EB21FC814A005B1585 /* NodeGraph.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NodeGraph.h; sourceTree = "<group>"; };
 		405038EC21FC814A005B1585 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -83,6 +111,8 @@
 		4050397621FC9EDD005B1585 /* AssembleColorNode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AssembleColorNode.m; sourceTree = "<group>"; };
 		4050397A21FCA8A4005B1585 /* UpdateBackgroundColorNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UpdateBackgroundColorNode.h; sourceTree = "<group>"; };
 		4050397B21FCA8A4005B1585 /* UpdateBackgroundColorNode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UpdateBackgroundColorNode.m; sourceTree = "<group>"; };
+		408EC85E232BA3A900185B35 /* NodeInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeInputTests.swift; sourceTree = "<group>"; };
+		408EC860232BEDC200185B35 /* AbstractNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractNodeTests.swift; sourceTree = "<group>"; };
 		40C08F612210C34500FD01AE /* NodeGraph.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NodeGraph.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		40C08F632210C34500FD01AE /* NodeGraph.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NodeGraph.h; sourceTree = "<group>"; };
 		40C08F642210C34500FD01AE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -102,6 +132,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		404974402327717D00B04589 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		404974482327717D00B04589 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4049744C2327717D00B04589 /* NodeGraphSwift_ios.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		405038E521FC814A005B1585 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -281,12 +326,55 @@
 			path = InputTypes;
 			sourceTree = "<group>";
 		};
+		404974442327717D00B04589 /* NodeGraphSwift-ios */ = {
+			isa = PBXGroup;
+			children = (
+				40101E79232B932F00D6EC69 /* module.modulemap */,
+				4049745A232771DB00B04589 /* include */,
+				404974452327717D00B04589 /* NodeGraphSwift_ios.h */,
+				404974462327717D00B04589 /* Info.plist */,
+			);
+			path = "NodeGraphSwift-ios";
+			sourceTree = "<group>";
+		};
+		4049744F2327717D00B04589 /* NodeGraphSwift-iosTests */ = {
+			isa = PBXGroup;
+			children = (
+				404974502327717D00B04589 /* NodeGraphSwift_iosTests.swift */,
+				404974522327717D00B04589 /* Info.plist */,
+				40101E73232B90E800D6EC69 /* NodeOutputTests.swift */,
+				408EC85E232BA3A900185B35 /* NodeInputTests.swift */,
+				408EC860232BEDC200185B35 /* AbstractNodeTests.swift */,
+			);
+			path = "NodeGraphSwift-iosTests";
+			sourceTree = "<group>";
+		};
+		4049745A232771DB00B04589 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				4049745B232771E800B04589 /* common */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		4049745B232771E800B04589 /* common */ = {
+			isa = PBXGroup;
+			children = (
+				4049745C2327720000B04589 /* Node.swift */,
+				40101E6F232A51CD00D6EC69 /* NodeInput.swift */,
+				40101E71232A51F100D6EC69 /* NodeOutput.swift */,
+			);
+			path = common;
+			sourceTree = "<group>";
+		};
 		405038DE21FC814A005B1585 = {
 			isa = PBXGroup;
 			children = (
 				4050390221FC8198005B1585 /* Include */,
 				405038EA21FC814A005B1585 /* source */,
 				405038F521FC814A005B1585 /* tests */,
+				404974442327717D00B04589 /* NodeGraphSwift-ios */,
+				4049744F2327717D00B04589 /* NodeGraphSwift-iosTests */,
 				405038E921FC814A005B1585 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -297,6 +385,8 @@
 				405038E821FC814A005B1585 /* NodeGraph.framework */,
 				405038F121FC814A005B1585 /* NodeGraphTests.xctest */,
 				40C08F612210C34500FD01AE /* NodeGraph.framework */,
+				404974432327717D00B04589 /* NodeGraphSwift_ios.framework */,
+				4049744B2327717D00B04589 /* NodeGraphSwift-iosTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -355,6 +445,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		4049743E2327717D00B04589 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				404974532327717D00B04589 /* NodeGraphSwift_ios.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		405038E321FC814A005B1585 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -393,6 +491,42 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		404974422327717D00B04589 /* NodeGraphSwift-ios */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 404974582327717D00B04589 /* Build configuration list for PBXNativeTarget "NodeGraphSwift-ios" */;
+			buildPhases = (
+				4049743E2327717D00B04589 /* Headers */,
+				4049743F2327717D00B04589 /* Sources */,
+				404974402327717D00B04589 /* Frameworks */,
+				404974412327717D00B04589 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "NodeGraphSwift-ios";
+			productName = "NodeGraphSwift-ios";
+			productReference = 404974432327717D00B04589 /* NodeGraphSwift_ios.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		4049744A2327717D00B04589 /* NodeGraphSwift-iosTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 404974592327717D00B04589 /* Build configuration list for PBXNativeTarget "NodeGraphSwift-iosTests" */;
+			buildPhases = (
+				404974472327717D00B04589 /* Sources */,
+				404974482327717D00B04589 /* Frameworks */,
+				404974492327717D00B04589 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4049744E2327717D00B04589 /* PBXTargetDependency */,
+			);
+			name = "NodeGraphSwift-iosTests";
+			productName = "NodeGraphSwift-iosTests";
+			productReference = 4049744B2327717D00B04589 /* NodeGraphSwift-iosTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		405038E721FC814A005B1585 /* NodeGraph-ios */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 405038FC21FC814A005B1585 /* Build configuration list for PBXNativeTarget "NodeGraph-ios" */;
@@ -453,9 +587,17 @@
 		405038DF21FC814A005B1585 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 1020;
 				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = NodeGraph;
 				TargetAttributes = {
+					404974422327717D00B04589 = {
+						CreatedOnToolsVersion = 10.2.1;
+						LastSwiftMigration = 1020;
+					};
+					4049744A2327717D00B04589 = {
+						CreatedOnToolsVersion = 10.2.1;
+					};
 					405038E721FC814A005B1585 = {
 						CreatedOnToolsVersion = 10.1;
 					};
@@ -482,11 +624,27 @@
 				405038E721FC814A005B1585 /* NodeGraph-ios */,
 				405038F021FC814A005B1585 /* NodeGraphTests */,
 				40C08F602210C34500FD01AE /* NodeGraph-macos */,
+				404974422327717D00B04589 /* NodeGraphSwift-ios */,
+				4049744A2327717D00B04589 /* NodeGraphSwift-iosTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		404974412327717D00B04589 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		404974492327717D00B04589 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		405038E621FC814A005B1585 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -511,6 +669,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4049743F2327717D00B04589 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				40101E70232A51CD00D6EC69 /* NodeInput.swift in Sources */,
+				40101E7A232B932F00D6EC69 /* module.modulemap in Sources */,
+				4049745D2327720000B04589 /* Node.swift in Sources */,
+				40101E72232A51F100D6EC69 /* NodeOutput.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		404974472327717D00B04589 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				40101E74232B90E800D6EC69 /* NodeOutputTests.swift in Sources */,
+				408EC85F232BA3A900185B35 /* NodeInputTests.swift in Sources */,
+				40101E78232B91DE00D6EC69 /* NodeGraphSwift_iosTests.swift in Sources */,
+				408EC861232BEDC200185B35 /* AbstractNodeTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		405038E421FC814A005B1585 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -558,6 +738,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		4049744E2327717D00B04589 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 404974422327717D00B04589 /* NodeGraphSwift-ios */;
+			targetProxy = 4049744D2327717D00B04589 /* PBXContainerItemProxy */;
+		};
 		405038F421FC814A005B1585 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 405038E721FC814A005B1585 /* NodeGraph-ios */;
@@ -566,6 +751,110 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		404974542327717D00B04589 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = UR3JNX8K6N;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "NodeGraphSwift-ios/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "$(SRCROOT)/NodeGraphSwift-ios/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = "node-graph.NodeGraphSwift-ios";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		404974552327717D00B04589 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = UR3JNX8K6N;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "NodeGraphSwift-ios/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "$(SRCROOT)/NodeGraphSwift-ios/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = "node-graph.NodeGraphSwift-ios";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		404974562327717D00B04589 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = UR3JNX8K6N;
+				INFOPLIST_FILE = "NodeGraphSwift-iosTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "node-graph.NodeGraphSwift-iosTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		404974572327717D00B04589 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = UR3JNX8K6N;
+				INFOPLIST_FILE = "NodeGraphSwift-iosTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "node-graph.NodeGraphSwift-iosTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		405038FA21FC814A005B1585 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -829,6 +1118,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		404974582327717D00B04589 /* Build configuration list for PBXNativeTarget "NodeGraphSwift-ios" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				404974542327717D00B04589 /* Debug */,
+				404974552327717D00B04589 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		404974592327717D00B04589 /* Build configuration list for PBXNativeTarget "NodeGraphSwift-iosTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				404974562327717D00B04589 /* Debug */,
+				404974572327717D00B04589 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		405038E221FC814A005B1585 /* Build configuration list for PBXProject "NodeGraph" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/NodeGraph.xcodeproj/project.pbxproj
+++ b/NodeGraph.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		40101E72232A51F100D6EC69 /* NodeOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40101E71232A51F100D6EC69 /* NodeOutput.swift */; };
 		40101E74232B90E800D6EC69 /* NodeOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40101E73232B90E800D6EC69 /* NodeOutputTests.swift */; };
 		40101E78232B91DE00D6EC69 /* NodeGraphSwift_iosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404974502327717D00B04589 /* NodeGraphSwift_iosTests.swift */; };
+		403D09D72345C62800F50750 /* SerializableNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403D09D62345C62800F50750 /* SerializableNodeTests.swift */; };
+		403D09D923479B3100F50750 /* GraphNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403D09D823479B3100F50750 /* GraphNode.swift */; };
 		4049744C2327717D00B04589 /* NodeGraphSwift_ios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 404974432327717D00B04589 /* NodeGraphSwift_ios.framework */; };
 		404974532327717D00B04589 /* NodeGraphSwift_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = 404974452327717D00B04589 /* NodeGraphSwift_ios.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4049745D2327720000B04589 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4049745C2327720000B04589 /* Node.swift */; };
@@ -85,6 +87,8 @@
 		40101E71232A51F100D6EC69 /* NodeOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeOutput.swift; sourceTree = "<group>"; };
 		40101E73232B90E800D6EC69 /* NodeOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeOutputTests.swift; sourceTree = "<group>"; };
 		40101E79232B932F00D6EC69 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		403D09D62345C62800F50750 /* SerializableNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializableNodeTests.swift; sourceTree = "<group>"; };
+		403D09D823479B3100F50750 /* GraphNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphNode.swift; sourceTree = "<group>"; };
 		404974432327717D00B04589 /* NodeGraphSwift_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NodeGraphSwift_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		404974452327717D00B04589 /* NodeGraphSwift_ios.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NodeGraphSwift_ios.h; sourceTree = "<group>"; };
 		404974462327717D00B04589 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -344,6 +348,7 @@
 				40101E73232B90E800D6EC69 /* NodeOutputTests.swift */,
 				408EC85E232BA3A900185B35 /* NodeInputTests.swift */,
 				408EC860232BEDC200185B35 /* AbstractNodeTests.swift */,
+				403D09D62345C62800F50750 /* SerializableNodeTests.swift */,
 			);
 			path = "NodeGraphSwift-iosTests";
 			sourceTree = "<group>";
@@ -362,6 +367,7 @@
 				4049745C2327720000B04589 /* Node.swift */,
 				40101E6F232A51CD00D6EC69 /* NodeInput.swift */,
 				40101E71232A51F100D6EC69 /* NodeOutput.swift */,
+				403D09D823479B3100F50750 /* GraphNode.swift */,
 			);
 			path = common;
 			sourceTree = "<group>";
@@ -674,6 +680,7 @@
 			files = (
 				40101E70232A51CD00D6EC69 /* NodeInput.swift in Sources */,
 				4049745D2327720000B04589 /* Node.swift in Sources */,
+				403D09D923479B3100F50750 /* GraphNode.swift in Sources */,
 				40101E72232A51F100D6EC69 /* NodeOutput.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -686,6 +693,7 @@
 				408EC85F232BA3A900185B35 /* NodeInputTests.swift in Sources */,
 				40101E78232B91DE00D6EC69 /* NodeGraphSwift_iosTests.swift in Sources */,
 				408EC861232BEDC200185B35 /* AbstractNodeTests.swift in Sources */,
+				403D09D72345C62800F50750 /* SerializableNodeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -974,10 +982,10 @@
 		405038FD21FC814A005B1585 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = UR3JNX8K6N;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -998,10 +1006,10 @@
 		405038FE21FC814A005B1585 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = UR3JNX8K6N;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/NodeGraph.xcodeproj/xcshareddata/xcschemes/NodeGraphSwift-ios.xcscheme
+++ b/NodeGraph.xcodeproj/xcshareddata/xcschemes/NodeGraphSwift-ios.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "404974422327717D00B04589"
+               BuildableName = "NodeGraphSwift_ios.framework"
+               BlueprintName = "NodeGraphSwift-ios"
+               ReferencedContainer = "container:NodeGraph.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "404974422327717D00B04589"
+            BuildableName = "NodeGraphSwift_ios.framework"
+            BlueprintName = "NodeGraphSwift-ios"
+            ReferencedContainer = "container:NodeGraph.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4049744A2327717D00B04589"
+               BuildableName = "NodeGraphSwift-iosTests.xctest"
+               BlueprintName = "NodeGraphSwift-iosTests"
+               ReferencedContainer = "container:NodeGraph.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "404974422327717D00B04589"
+            BuildableName = "NodeGraphSwift_ios.framework"
+            BlueprintName = "NodeGraphSwift-ios"
+            ReferencedContainer = "container:NodeGraph.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "404974422327717D00B04589"
+            BuildableName = "NodeGraphSwift_ios.framework"
+            BlueprintName = "NodeGraphSwift-ios"
+            ReferencedContainer = "container:NodeGraph.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "404974422327717D00B04589"
+            BuildableName = "NodeGraphSwift_ios.framework"
+            BlueprintName = "NodeGraphSwift-ios"
+            ReferencedContainer = "container:NodeGraph.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/NodeGraphSwift-ios/Info.plist
+++ b/NodeGraphSwift-ios/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/NodeGraphSwift-ios/NodeGraphSwift_ios.h
+++ b/NodeGraphSwift-ios/NodeGraphSwift_ios.h
@@ -1,0 +1,17 @@
+//
+//  NodeGraphSwift_ios.h
+//  NodeGraphSwift-ios
+//
+//  Created by Mikael Sundström on 2019-09-10.
+//  Copyright © 2019 NodeGraph. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for NodeGraphSwift_ios.
+FOUNDATION_EXPORT double NodeGraphSwift_iosVersionNumber;
+
+//! Project version string for NodeGraphSwift_ios.
+FOUNDATION_EXPORT const unsigned char NodeGraphSwift_iosVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <NodeGraphSwift_ios/PublicHeader.h>

--- a/NodeGraphSwift-ios/include/common/GraphNode.swift
+++ b/NodeGraphSwift-ios/include/common/GraphNode.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+class GraphNode: NSObject {
+    var serializeable: Bool {
+        for node in nodes {
+            guard let _ = node as? SerializableNode else {
+                return false
+            }
+        }
+        
+        return true
+    }
+    private(set) var nodes: Set<AnyHashable> = Set<AnyHashable>()
+    
+    func set<HashableNode>(nodeSet: Set<HashableNode>) where HashableNode: Node, HashableNode: Hashable {
+        nodes = nodeSet
+    }
+}
+

--- a/NodeGraphSwift-ios/include/common/Node.swift
+++ b/NodeGraphSwift-ios/include/common/Node.swift
@@ -134,12 +134,14 @@ class AbstractNode: Node, NodeInputDelegate {
      */
     func process() {
         guard !isProcessing else {
+            print("is processing - quitting")
             return
         }
         
         isProcessing = true
         processingStartTime = Date().timeIntervalSince1970
         if useDeferredProcessing {
+            print("using deferred")
             processDeferred()
         } else {
             processDirectly()
@@ -185,15 +187,19 @@ class AbstractNode: Node, NodeInputDelegate {
     private func processDeferred() {
         DispatchQueue.main.async {[weak self] in
             guard let strongSelf = self else {
+                print("self doesnt exist")
                 return
             }
-            
+            print("deferred call being made")
             strongSelf.processDirectly()
         }
+        
+        print("deferred call set up!")
     }
     
     private func processDirectly() {
         doProcess {[weak self] in
+            print("in doProcess completion")
             guard let strongSelf = self else {
                 return
             }

--- a/NodeGraphSwift-ios/include/common/Node.swift
+++ b/NodeGraphSwift-ios/include/common/Node.swift
@@ -1,0 +1,244 @@
+import Foundation
+
+/**
+ Decides what inputs need to be set in order for a node to process.
+ */
+enum NodeInputTrigger {
+    /// The node does not automatically process anything, you manually have to call the -process method.
+    case noAutomaticProcessing
+    /// Process as soon as any input is set.
+    case any
+    /// All inputs have to be triggered between each run for the node to process.
+    case all
+    /// Same as NodeInputRequirementAll but keeps the value so next run can start whenever any input is set.
+    case allAtLeastOnce
+    /// The processing behaviour is custom and driven by the node itself.
+    case custom
+}
+
+/**
+ A Node in NodeGraph can have multiple inputs of varying types as well as many outputs of
+ different types.
+ 
+ Let't take an Add Node as the simplest example. It would require at least two
+ inputs but the result would only be one value. Downstream nodes can be
+ specified in the outputs property however but they all receive the same result.
+ 
+ 
+ Node example:
+ 
+ 20         4
+ \        /
+ --I0----I1--
+ |            |
+ |   Divide   |
+ |  O = A / B |
+ |            |
+ -----O0-----
+      |
+      5
+ 
+ */
+protocol Node {
+    /**
+     Specifies what inputs need to be set in order for the node to process.
+     */
+    var inputTrigger: NodeInputTrigger { get }
+    
+    /**
+     The inputs of this node, inputs do not reference upstream nodes but keeps a
+     result from an upstream node that this node can use when -process is called.
+     */
+    var inputs: Set<NodeInput> { get }
+    
+    /**
+     All downstream connections out from this node. When -process is run the result
+     will be fed to each NodeOutput.
+     */
+    var outputs: Set<NodeOutput> { get }
+    
+    /**
+     Human readable name of the node.
+     */
+    var nodeName: String? { get }
+    
+    /**
+     Describes what the node does or can be used for.
+     */
+    var nodeDescription: String? { get }
+    
+    /**
+     Processes the node with the current values stored in the inputs of this node.
+     All outputs will be triggered with the result of this nodes operation.
+     
+     This method will also be triggered internally based on the inputTrigger specified by the node.
+     */
+    func process()
+    
+    /**
+     Cancels the current processing and stops the result from flowing to any
+     downstream nodes. Also recursively cancels any downstream connections.
+     */
+    func cancel()
+}
+
+class AbstractNode: Node, NodeInputDelegate {
+    var inputTrigger: NodeInputTrigger
+    var inputs: Set<NodeInput>
+    var outputs: Set<NodeOutput>
+    var nodeName: String?
+    var nodeDescription: String?
+    
+    /**
+     This method is called when processing is started to decide if the -doProcess:
+     method should be called directly or deferred.
+     The default behaviour looks at the number of inputs together with the
+     inputTrigger property. Only override this method if the default behaviour is
+     not suited for your application.
+     
+     The reason for deferring the processing call is to not run your implementation
+     of the work that your node performs and all downstream nodes if multiple input
+     parameters are being set in the same runloop.
+     */
+    var useDeferredProcessing: Bool {
+        let couldTriggerOnAnyInput = (
+            inputTrigger == .any ||
+            inputTrigger == .allAtLeastOnce ||
+            inputTrigger == .custom
+        )
+        return (inputs.count > 1 && couldTriggerOnAnyInput)
+    }
+    
+    private(set) var isProcessing: Bool
+    private(set) var processingTime: TimeInterval
+    private var processingStartTime: TimeInterval
+    private var cancelling: Bool
+    
+    init() {
+        processingTime = 0
+        inputTrigger = .any
+        inputs = Set<NodeInput>()
+        outputs = Set<NodeOutput>()
+        isProcessing = false
+        cancelling = false
+        processingTime = 0.0
+        processingStartTime = 0.0
+        
+    }
+    
+    // MARK: Actions
+    
+    /**
+     Do not override this method directly to add your functionality. Instead
+     override the -doProcess: method.
+     */
+    func process() {
+        guard !isProcessing else {
+            return
+        }
+        
+        isProcessing = true
+        processingStartTime = Date().timeIntervalSince1970
+        if useDeferredProcessing {
+            processDeferred()
+        } else {
+            processDirectly()
+        }
+    }
+    
+    func cancel() {
+        guard !cancelling else {
+            return
+        }
+        
+        cancelling = true
+        for output in outputs {
+            for connection in output.connections.allObjects {
+                guard let connectionNode = connection.node else {
+                    return
+                }
+                connectionNode.cancel()
+            }
+        }
+    }
+    
+    /**
+     @abstract
+     Implement this method with your Node functionality.
+     1, Process input values
+     2, Send result to each respective output
+     3, Call completion block when done
+     */
+    func doProcess(_ completion: @escaping () -> Void) {
+        sendResultsToOutputs(inputs.randomElement()?.value)
+        completion()
+    }
+    
+    private func sendResultsToOutputs(_ results: AnyHashable?) {
+        for output in outputs {
+            output.send(result: results)
+        }
+    }
+    
+    // MARK: Processing
+    
+    private func processDeferred() {
+        DispatchQueue.main.async {[weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            
+            strongSelf.processDirectly()
+        }
+    }
+    
+    private func processDirectly() {
+        doProcess {[weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.processingTime = Date().timeIntervalSince1970 - strongSelf.processingTime
+            strongSelf.isProcessing = false
+        }
+    }
+    
+    func nodeInputDidUpdateValue(_: NodeInput, value: AnyHashable?) {
+        if canRun() {
+            process()
+        }
+    }
+    
+    private func canRun() -> Bool {
+        var canRunNode = false
+        switch inputTrigger {
+        case .any:
+            canRunNode = false
+            for input in inputs {
+                if input.value != nil {
+                    canRunNode = true
+                    continue
+                }
+            }
+            break
+        case .all:
+            canRunNode = true
+            for input in inputs {
+                if input.value == nil {
+                    canRunNode = false
+                }
+            }
+            break
+        case .allAtLeastOnce:
+            // TODO
+            break
+        case .noAutomaticProcessing:
+            canRunNode = false
+            break
+        case .custom:
+            canRunNode = true
+            break
+        }
+        
+        return canRunNode
+    }
+}

--- a/NodeGraphSwift-ios/include/common/Node.swift
+++ b/NodeGraphSwift-ios/include/common/Node.swift
@@ -216,7 +216,7 @@ class AbstractNode: Node, NodeInputDelegate {
             for input in inputs {
                 if input.value != nil {
                     canRunNode = true
-                    continue
+                    break
                 }
             }
             break

--- a/NodeGraphSwift-ios/include/common/NodeInput.swift
+++ b/NodeGraphSwift-ios/include/common/NodeInput.swift
@@ -1,0 +1,102 @@
+
+/**
+ Defines how a node input communicates changes.
+ */
+protocol NodeInputDelegate {
+    func nodeInputDidUpdateValue(_: NodeInput, value:AnyHashable?) -> Void
+}
+
+/**
+ A type of input for a \c Node. This decides what type of input a node can accept.
+ A node can accept more than one input by defining more of these.
+ 
+ This class is well suited for subclassing so you can implement inputs for specific types.
+ */
+class NodeInput: Hashable {
+    typealias NodeAndDelegate = Node & NodeInputDelegate
+    
+    /**
+     The current value of the input. The setter will run the validationBlock before
+     trying to store the value.
+     */
+    var value: AnyHashable? {
+        set {
+            guard valueIsValid(newValue) else {
+                return
+            }
+            
+            if _value != nil && _value == newValue {
+                return
+            }
+            
+            _value = newValue
+            
+            if let node = node {
+                node.nodeInputDidUpdateValue(self, value: _value)
+            }
+        }
+        get {
+            return _value
+        }
+    }
+    private var _value: AnyHashable?
+    
+    /**
+     The node that this input beloongs to. Receives events regarding input changes.
+     */
+    var node: NodeAndDelegate?
+    
+    /**
+     The optional key of this input for the node.
+     */
+    private(set) var key: String?
+    
+    /**
+     The block that validates incoming values.
+     */
+    private(set) var validationBlock: ((_: AnyHashable?) -> Bool)?
+    
+    init() {
+        key = nil
+        node = nil
+    }
+    
+    /**
+     Create a new input.
+     */
+    init(withKey key: String?,
+         forNode node: NodeAndDelegate?) {
+        self.key = key
+        self.node = node
+    }
+    
+    /**
+     Create a new input.
+     */
+    init(withKey key: String?,
+         forNode node: NodeAndDelegate?,
+         withValidationBlock validationBlock: ((_: AnyHashable?) -> Bool)?) {
+        self.key = key
+        self.node = node
+        self.validationBlock = validationBlock
+    }
+    
+    static func == (lhs: NodeInput, rhs: NodeInput) -> Bool {
+        return lhs === rhs
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(node?.nodeName)
+        hasher.combine(key)
+    }
+    
+    /**
+     Checks if value is valid or not.
+     */
+    func valueIsValid(_ value: AnyHashable?) -> Bool {
+        guard let validationBlock = validationBlock else {
+            return true
+        }
+        return validationBlock(value)
+    }
+}

--- a/NodeGraphSwift-ios/include/common/NodeInput.swift
+++ b/NodeGraphSwift-ios/include/common/NodeInput.swift
@@ -12,7 +12,7 @@ protocol NodeInputDelegate {
  
  This class is well suited for subclassing so you can implement inputs for specific types.
  */
-class NodeInput: Hashable {
+class NodeInput: Hashable, Codable {
     typealias NodeAndDelegate = Node & NodeInputDelegate
     
     /**
@@ -56,6 +56,12 @@ class NodeInput: Hashable {
      */
     private(set) var validationBlock: ((_: AnyHashable?) -> Bool)?
     
+    
+    private enum CodingKeys: String, CodingKey {
+        case key = "key"
+        case type = "type"
+    }
+    
     init() {
 
     }
@@ -67,6 +73,10 @@ class NodeInput: Hashable {
          forNode node: NodeAndDelegate?) {
         self.key = key
         self.node = node
+    }
+    
+    required init(from decoder: Decoder) throws {
+        fatalError()
     }
     
     /**
@@ -87,6 +97,12 @@ class NodeInput: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(node?.nodeName)
         hasher.combine(key)
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(key ?? "no_key", forKey: .key)
+        try container.encode(String(describing:type(of: self)), forKey: .type)
     }
     
     /**

--- a/NodeGraphSwift-ios/include/common/NodeInput.swift
+++ b/NodeGraphSwift-ios/include/common/NodeInput.swift
@@ -39,17 +39,17 @@ class NodeInput: Hashable {
             return _value
         }
     }
-    private var _value: AnyHashable?
+    private var _value: AnyHashable? = nil
     
     /**
      The node that this input beloongs to. Receives events regarding input changes.
      */
-    var node: NodeAndDelegate?
+    var node: NodeAndDelegate? = nil
     
     /**
      The optional key of this input for the node.
      */
-    private(set) var key: String?
+    private(set) var key: String? = nil
     
     /**
      The block that validates incoming values.
@@ -57,8 +57,7 @@ class NodeInput: Hashable {
     private(set) var validationBlock: ((_: AnyHashable?) -> Bool)?
     
     init() {
-        key = nil
-        node = nil
+
     }
     
     /**

--- a/NodeGraphSwift-ios/include/common/NodeOutput.swift
+++ b/NodeGraphSwift-ios/include/common/NodeOutput.swift
@@ -11,20 +11,19 @@ class NodeOutput: Hashable {
      The key of this output, can be nil if the node only has one output.
      An example value for this could be the `R` output key in an `RGB` node.
      */
-    private(set) var key: String?
+    private(set) var key: String? = nil
     
     /**
      The downstream node inputs that gets the result of this output.
      @warning Please do not mutate this object directly.
      */
-    private(set) var connections: NSHashTable<NodeInput>
+    private(set) var connections: NSHashTable<NodeInput> = NSHashTable(options: NSPointerFunctions.Options.weakMemory)
     
     /**
      Creates an output without a key.
      */
     init() {
-        key = nil
-        connections = NSHashTable(options: NSPointerFunctions.Options.weakMemory)
+
     }
     
     /**

--- a/NodeGraphSwift-ios/include/common/NodeOutput.swift
+++ b/NodeGraphSwift-ios/include/common/NodeOutput.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/**
+ A representation of an output from a Node. An output can be named with a key to
+ signify what part of the result it carries.
+ 
+ An output has connections as weak references to instances of NodeInput.
+ */
+class NodeOutput: Hashable {
+    /**
+     The key of this output, can be nil if the node only has one output.
+     An example value for this could be the `R` output key in an `RGB` node.
+     */
+    private(set) var key: String?
+    
+    /**
+     The downstream node inputs that gets the result of this output.
+     @warning Please do not mutate this object directly.
+     */
+    private(set) var connections: NSHashTable<NodeInput>
+    
+    /**
+     Creates an output without a key.
+     */
+    init() {
+        key = nil
+        connections = NSHashTable(options: NSPointerFunctions.Options.weakMemory)
+    }
+    
+    /**
+     Creates an output with a key/name.
+     */
+    init(withKey key: String) {
+        self.key = key
+        connections = NSHashTable(options: NSPointerFunctions.Options.weakMemory)
+    }
+    
+    static func == (lhs: NodeOutput, rhs: NodeOutput) -> Bool {
+        return lhs === rhs
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(key)
+        hasher.combine(connections)
+    }
+    
+    /**
+     Adds a downstream connection from this output.
+     */
+    func addConnection(nodeInput: NodeInput) {
+        connections.add(nodeInput)
+    }
+    
+    /**
+     Removes a downstream connection from this output.
+     */
+    func removeConnection(nodeInput: NodeInput) {
+        connections.remove(nodeInput)
+    }
+    
+    /**
+     Sends the result to each connection.
+     */
+    func send(result: AnyHashable?) {
+        for connection in connections.allObjects {
+            connection.value = result
+        }
+    }
+}

--- a/NodeGraphSwift-ios/include/common/NodeOutput.swift
+++ b/NodeGraphSwift-ios/include/common/NodeOutput.swift
@@ -6,7 +6,7 @@ import Foundation
  
  An output has connections as weak references to instances of NodeInput.
  */
-class NodeOutput: Hashable {
+class NodeOutput: Hashable, Codable {
     /**
      The key of this output, can be nil if the node only has one output.
      An example value for this could be the `R` output key in an `RGB` node.
@@ -18,6 +18,11 @@ class NodeOutput: Hashable {
      @warning Please do not mutate this object directly.
      */
     private(set) var connections: NSHashTable<NodeInput> = NSHashTable(options: NSPointerFunctions.Options.weakMemory)
+    
+    private enum CodingKeys: String, CodingKey {
+        case key = "key"
+        case type = "type"
+    }
     
     /**
      Creates an output without a key.
@@ -34,6 +39,10 @@ class NodeOutput: Hashable {
         connections = NSHashTable(options: NSPointerFunctions.Options.weakMemory)
     }
     
+    required init(from decoder: Decoder) throws {
+        fatalError()
+    }
+    
     static func == (lhs: NodeOutput, rhs: NodeOutput) -> Bool {
         return lhs === rhs
     }
@@ -41,6 +50,12 @@ class NodeOutput: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(key)
         hasher.combine(connections)
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(key ?? "no_key", forKey: .key)
+        try container.encode(String(describing: type(of: self)), forKey: .type)
     }
     
     /**

--- a/NodeGraphSwift-ios/module.modulemap
+++ b/NodeGraphSwift-ios/module.modulemap
@@ -1,0 +1,3 @@
+framework module NodeGraphSwift_ios {
+    export *
+}

--- a/NodeGraphSwift-iosTests/AbstractNodeTests.swift
+++ b/NodeGraphSwift-iosTests/AbstractNodeTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import NodeGraphSwift_ios
+
+class _DeferredTestNode: AbstractNode {
+    var processed: (() -> Void)? = nil
+    var cancelled: (() -> Void)? = nil
+    var aInput: NodeInput!
+    var bInput: NodeInput!
+    var aOutput: NodeOutput!
+    var deferred: Bool
+    
+    override var useDeferredProcessing: Bool {
+        return deferred
+    }
+    
+    override init() {
+        deferred = false
+        aOutput = NodeOutput(withKey: "a")
+        
+        super.init()
+        
+        aInput = NodeInput(withKey: "a", forNode: self)
+        bInput = NodeInput(withKey: "b", forNode: self)
+        
+        inputs = Set<NodeInput>([aInput, bInput])
+        outputs = Set<NodeOutput>([aOutput])
+    }
+    
+    override func doProcess(_ completion: @escaping () -> Void) {
+        completion()
+        if let processedCallback = processed {
+            processedCallback()
+        }
+    }
+    
+    override func cancel() {
+        super.cancel()
+        if let cancelledCallback = cancelled {
+            cancelledCallback()
+        }
+    }
+}
+
+class AbstractNodeTests: XCTestCase {
+
+    var abstractNode: AbstractNode!
+    var deferredTestNode: _DeferredTestNode!
+    var performanceInterations: NSInteger!
+    
+    override func setUp() {
+        abstractNode = AbstractNode()
+        abstractNode.inputs.insert(NodeInput(withKey: nil, forNode: abstractNode))
+        abstractNode.outputs.insert(NodeOutput())
+        
+        deferredTestNode = _DeferredTestNode()
+        
+        performanceInterations = 8000
+    }
+    
+    // MARK: Input to Output
+    func test_inputTriggersProcessingToOutputConnections() {
+        let connection = NodeInput(withKey: nil, forNode: nil)
+        let value = NSNumber(42)
+        
+        abstractNode.outputs.randomElement()?.addConnection(nodeInput: connection)
+        abstractNode.inputs.randomElement()?.value = value
+        
+        XCTAssertEqual(connection.value, value)
+    }
+    
+    func test_cancelOperationForwardsCancelRecursivly() {
+        var cancelCalled = false
+        deferredTestNode.cancelled = {
+            cancelCalled = true
+        }
+        
+        abstractNode.outputs.randomElement()?.addConnection(nodeInput: deferredTestNode.aInput)
+        abstractNode.cancel()
+        XCTAssertTrue(cancelCalled)
+    }
+    
+    // MARK: Cancelling
+    func test_cancelOperationInCircularGraphsDoesNotTriggerInfiniteLoop() {
+        var cancelCallCount = 0
+        deferredTestNode.cancelled = {
+            cancelCallCount += 1
+        }
+        
+        abstractNode.outputs.randomElement()?.addConnection(nodeInput: deferredTestNode.aInput)
+        deferredTestNode.aOutput.addConnection(nodeInput: abstractNode.inputs.randomElement()!)
+        abstractNode.cancel()
+        XCTAssertEqual(cancelCallCount, 1)
+    }
+    
+    // MARK: Deferred processing
+    // TODO: crashes with BAD_EXEC
+//    func test_directProcessingPerformance() {
+//        let measureExpectation = expectation(description: "Measure time")
+//
+//        measure(block: {[weak self] (completion) in
+//            guard let strongSelf = self else {
+//                print("FAILED")
+//                return
+//            }
+//            strongSelf.abstractNode.process()
+//            completion()
+//        }, iterations: performanceInterations!) {[weak self] (time) in
+//            guard let strongSelf = self else {
+//                print("FAILED")
+//                return
+//            }
+//            let totalTime = time * 1000
+//            let averageTime = totalTime / Double(strongSelf.performanceInterations!)
+//
+//            print("Deferred processing performance Total (ms): \(String(describing: totalTime)) Average (ms): \(String(describing: averageTime)) Iterations: \(String(describing: strongSelf.performanceInterations))")
+//            measureExpectation.fulfill()
+//        }
+//
+//        waitForExpectations(timeout: 9.0, handler: nil)
+//    }
+    
+    // TODO: Fails on time
+//    func test_deferredProcessingPerformance() {
+//        let measureExpectation = expectation(description: "measure time")
+//        measure(block: {[weak self] (completion) in
+//            guard let strongSelf = self else {
+//                return
+//            }
+//            strongSelf.deferredTestNode.processed = {
+//                completion()
+//            }
+//        }, iterations: 10000) {[weak self] (time) in
+//            guard let strongSelf = self else {
+//                print("FAILED")
+//                return
+//            }
+//            let totalTime = time * 1000
+//            let averageTime = totalTime / Double(strongSelf.performanceInterations!)
+//
+//            print("Deferred processing performance Total (ms): \(String(describing: totalTime)) Average (ms): \(String(describing: averageTime)) Iterations: \(String(describing: strongSelf.performanceInterations))")
+//            measureExpectation.fulfill()
+//        }
+//
+//        waitForExpectations(timeout: 20.0, handler: nil)
+//    }
+    
+    // MARK: Helpers
+    func measure(block: @escaping ((_ completion: @escaping () -> Void ) -> Void),
+                 iterations: NSInteger,
+                 completion: @escaping (_ time: TimeInterval) -> Void) {
+        var i = 0
+        let start = Date().timeIntervalSince1970
+        var testTime: TimeInterval = 0.0
+        var iterator: (() -> Void)? = nil
+        iterator = {
+            i += 1
+            block() {
+                if i < iterations {
+                    iterator!()
+                } else {
+                    testTime = Date().timeIntervalSince1970 - start
+                    completion(testTime)
+                }
+            }
+        }
+        
+        iterator!()
+    }
+}

--- a/NodeGraphSwift-iosTests/AbstractNodeTests.swift
+++ b/NodeGraphSwift-iosTests/AbstractNodeTests.swift
@@ -93,7 +93,6 @@ class AbstractNodeTests: XCTestCase {
     }
     
     // MARK: Deferred processing
-    // TODO: crashes with BAD_EXEC
     func test_directProcessingPerformance() {
         let measureExpectation = expectation(description: "Measure time")
 
@@ -112,48 +111,47 @@ class AbstractNodeTests: XCTestCase {
             let totalTime = time * 1000
             let averageTime = totalTime / Double(strongSelf.performanceInterations!)
 
-            print("Deferred processing performance Total (ms): \(String(describing: totalTime)) Average (ms): \(String(describing: averageTime)) Iterations: \(String(describing: strongSelf.performanceInterations))")
+            print("\nDeferred processing performance Total (ms): \(String(describing: totalTime)) \nAverage (ms): \(String(describing: averageTime)) \nIterations: \(String(describing: strongSelf.performanceInterations))\n")
             measureExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 9.0, handler: nil)
+        waitForExpectations(timeout: 4.0, handler: nil)
     }
     
-    // TODO: Fails on time
-//    func test_deferredProcessingPerformance() {
-//        let measureExpectation = expectation(description: "measure time")
-//        measure(block: {[weak self] (completion) in
-//            guard let strongSelf = self else {
-//                return
-//            }
-//            strongSelf.deferredTestNode.processed = {
-//                completion()
-//            }
-//        }, iterations: 10000) {[weak self] (time) in
-//            guard let strongSelf = self else {
-//                print("FAILED")
-//                return
-//            }
-//            let totalTime = time * 1000
-//            let averageTime = totalTime / Double(strongSelf.performanceInterations!)
-//
-//            print("Deferred processing performance Total (ms): \(String(describing: totalTime)) Average (ms): \(String(describing: averageTime)) Iterations: \(String(describing: strongSelf.performanceInterations))")
-//            measureExpectation.fulfill()
-//        }
-//
-//        waitForExpectations(timeout: 20.0, handler: nil)
-//    }
+    func test_deferredProcessingPerformance() {
+        let measureExpectation = expectation(description: "measure time")
+        measure(block: {[weak self] (completion) in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.deferredTestNode.processed = {
+                completion()
+            }
+            strongSelf.deferredTestNode.process()
+        }, iterations: 8000) {[weak self] (time) in
+            guard let strongSelf = self else {
+                print("FAILED")
+                return
+            }
+            let totalTime = time * 1000
+            let averageTime = totalTime / Double(strongSelf.performanceInterations!)
+
+            print("\nDeferred processing performance Total (ms): \(String(describing: totalTime)) \nAverage (ms): \(String(describing: averageTime)) \nIterations: \(String(describing: strongSelf.performanceInterations))\n")
+            measureExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
     
     // MARK: Helpers
     func measure(block: @escaping ((_ completion: @escaping () -> Void ) -> Void),
                  iterations: NSInteger,
                  completion: @escaping (_ time: TimeInterval) -> Void) {
-        var i = 0
         let start = Date().timeIntervalSince1970
         var testTime: TimeInterval = 0.0
         
-        var dispatchGroup = DispatchGroup()
-        for i in 0...iterations {
+        let dispatchGroup = DispatchGroup()
+        for _ in 0...iterations {
             dispatchGroup.enter()
             block() {
                 dispatchGroup.leave()

--- a/NodeGraphSwift-iosTests/AbstractNodeTests.swift
+++ b/NodeGraphSwift-iosTests/AbstractNodeTests.swift
@@ -94,30 +94,30 @@ class AbstractNodeTests: XCTestCase {
     
     // MARK: Deferred processing
     // TODO: crashes with BAD_EXEC
-//    func test_directProcessingPerformance() {
-//        let measureExpectation = expectation(description: "Measure time")
-//
-//        measure(block: {[weak self] (completion) in
-//            guard let strongSelf = self else {
-//                print("FAILED")
-//                return
-//            }
-//            strongSelf.abstractNode.process()
-//            completion()
-//        }, iterations: performanceInterations!) {[weak self] (time) in
-//            guard let strongSelf = self else {
-//                print("FAILED")
-//                return
-//            }
-//            let totalTime = time * 1000
-//            let averageTime = totalTime / Double(strongSelf.performanceInterations!)
-//
-//            print("Deferred processing performance Total (ms): \(String(describing: totalTime)) Average (ms): \(String(describing: averageTime)) Iterations: \(String(describing: strongSelf.performanceInterations))")
-//            measureExpectation.fulfill()
-//        }
-//
-//        waitForExpectations(timeout: 9.0, handler: nil)
-//    }
+    func test_directProcessingPerformance() {
+        let measureExpectation = expectation(description: "Measure time")
+
+        measure(block: {[weak self] (completion) in
+            guard let strongSelf = self else {
+                print("FAILED")
+                return
+            }
+            strongSelf.abstractNode.process()
+            completion()
+        }, iterations: performanceInterations!) {[weak self] (time) in
+            guard let strongSelf = self else {
+                print("FAILED")
+                return
+            }
+            let totalTime = time * 1000
+            let averageTime = totalTime / Double(strongSelf.performanceInterations!)
+
+            print("Deferred processing performance Total (ms): \(String(describing: totalTime)) Average (ms): \(String(describing: averageTime)) Iterations: \(String(describing: strongSelf.performanceInterations))")
+            measureExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 9.0, handler: nil)
+    }
     
     // TODO: Fails on time
 //    func test_deferredProcessingPerformance() {
@@ -151,19 +151,18 @@ class AbstractNodeTests: XCTestCase {
         var i = 0
         let start = Date().timeIntervalSince1970
         var testTime: TimeInterval = 0.0
-        var iterator: (() -> Void)? = nil
-        iterator = {
-            i += 1
+        
+        var dispatchGroup = DispatchGroup()
+        for i in 0...iterations {
+            dispatchGroup.enter()
             block() {
-                if i < iterations {
-                    iterator!()
-                } else {
-                    testTime = Date().timeIntervalSince1970 - start
-                    completion(testTime)
-                }
+                dispatchGroup.leave()
             }
         }
         
-        iterator!()
+        dispatchGroup.notify(queue: DispatchQueue.main) {
+            testTime = Date().timeIntervalSince1970 - start
+            completion(testTime)
+        }
     }
 }

--- a/NodeGraphSwift-iosTests/AbstractNodeTests.swift
+++ b/NodeGraphSwift-iosTests/AbstractNodeTests.swift
@@ -14,7 +14,7 @@ class _DeferredTestNode: AbstractNode {
     }
     
     override init() {
-        deferred = false
+        deferred = true
         aOutput = NodeOutput(withKey: "a")
         
         super.init()
@@ -54,7 +54,7 @@ class AbstractNodeTests: XCTestCase {
         
         deferredTestNode = _DeferredTestNode()
         
-        performanceInterations = 8000
+        performanceInterations = 10000
     }
     
     // MARK: Input to Output
@@ -128,7 +128,7 @@ class AbstractNodeTests: XCTestCase {
                 completion()
             }
             strongSelf.deferredTestNode.process()
-        }, iterations: 8000) {[weak self] (time) in
+        }, iterations: performanceInterations!) {[weak self] (time) in
             guard let strongSelf = self else {
                 print("FAILED")
                 return
@@ -200,10 +200,12 @@ class AbstractNodeTests: XCTestCase {
         var testTime: TimeInterval = 0.0
         
         let dispatchGroup = DispatchGroup()
-        for _ in 0...iterations {
+        for i in 0...iterations {
             dispatchGroup.enter()
+            print("enter \(i)")
             block() {
                 dispatchGroup.leave()
+                print("leave \(i)")
             }
         }
         

--- a/NodeGraphSwift-iosTests/AbstractNodeTests.swift
+++ b/NodeGraphSwift-iosTests/AbstractNodeTests.swift
@@ -26,6 +26,10 @@ class _DeferredTestNode: AbstractNode {
         outputs = Set<NodeOutput>([aOutput])
     }
     
+    required init(from decoder: Decoder) throws {
+        fatalError("init(from:) has not been implemented")
+    }
+    
     override func doProcess(_ completion: @escaping () -> Void) {
         print("[IN NODE - doProcess]: Processing deferred...")
         completion()
@@ -121,33 +125,35 @@ class AbstractNodeTests: XCTestCase {
         waitForExpectations(timeout: 4.0, handler: nil)
     }
     
-    func test_deferredProcessingPerformance() {
-        let measureExpectation = expectation(description: "measure time")
-        measure(block: {[weak self] (completion) in
-            print("Processing deferred...")
-            guard let strongSelf = self else {
-                print("self not existing ")
-                return
-            }
-            strongSelf.deferredTestNode.processed = {
-                print("Processing deferred done!")
-                completion()
-            }
-            strongSelf.deferredTestNode.process()
-        }, iterations: performanceInterations!) {[weak self] (time) in
-            guard let strongSelf = self else {
-                print("FAILED")
-                return
-            }
-            let totalTime = time * 1000
-            let averageTime = totalTime / Double(strongSelf.performanceInterations!)
-
-            print("\nDeferred processing performance Total (ms): \(String(describing: totalTime)) \nAverage (ms): \(String(describing: averageTime)) \nIterations: \(String(describing: strongSelf.performanceInterations))\n")
-            measureExpectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 5.0, handler: nil)
-    }
+// Disabled, not working
+    
+//    func test_deferredProcessingPerformance() {
+//        let measureExpectation = expectation(description: "measure time")
+//        measure(block: {[weak self] (completion) in
+//            print("Processing deferred...")
+//            guard let strongSelf = self else {
+//                print("self not existing ")
+//                return
+//            }
+//            strongSelf.deferredTestNode.processed = {
+//                print("Processing deferred done!")
+//                completion()
+//            }
+//            strongSelf.deferredTestNode.process()
+//        }, iterations: performanceInterations!) {[weak self] (time) in
+//            guard let strongSelf = self else {
+//                print("FAILED")
+//                return
+//            }
+//            let totalTime = time * 1000
+//            let averageTime = totalTime / Double(strongSelf.performanceInterations!)
+//
+//            print("\nDeferred processing performance Total (ms): \(String(describing: totalTime)) \nAverage (ms): \(String(describing: averageTime)) \nIterations: \(String(describing: strongSelf.performanceInterations))\n")
+//            measureExpectation.fulfill()
+//        }
+//
+//        waitForExpectations(timeout: 5.0, handler: nil)
+//    }
     
     func test_allARgumentsAreSetBeforeDeferredProcessing() {
         let argumentsExpectation = expectation(description: "Both arguments set")

--- a/NodeGraphSwift-iosTests/Info.plist
+++ b/NodeGraphSwift-iosTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/NodeGraphSwift-iosTests/NodeGraphSwift_iosTests.swift
+++ b/NodeGraphSwift-iosTests/NodeGraphSwift_iosTests.swift
@@ -1,0 +1,33 @@
+//
+//  NodeGraphSwift_iosTests.swift
+//  NodeGraphSwift-iosTests
+//
+//  Created by Mikael Sundström on 2019-09-10.
+//  Copyright © 2019 NodeGraph. All rights reserved.
+//
+
+import XCTest
+
+class NodeGraphSwift_iosTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/NodeGraphSwift-iosTests/NodeInputTests.swift
+++ b/NodeGraphSwift-iosTests/NodeInputTests.swift
@@ -1,0 +1,194 @@
+//
+//  NodeInputTests.swift
+//  NodeGraphSwift-iosTests
+//
+//  Created by Mikael Sundström on 2019-09-13.
+//  Copyright © 2019 NodeGraph. All rights reserved.
+//
+
+import XCTest
+@testable import NodeGraphSwift_ios
+
+class _NodeInputTestMockNode: AbstractNode {
+    var delegateCallCount: NSInteger
+    var delegateCaller: NodeInput? = nil
+    var delegateValue: AnyHashable? = nil
+    
+    override init() {
+        delegateCallCount = 0
+    }
+    
+    override func nodeInputDidUpdateValue(_ nodeInput: NodeInput, value: AnyHashable?) {
+        delegateCallCount += 1
+        delegateCaller = nodeInput
+        delegateValue = value
+    }
+}
+
+class NodeInputTests: XCTestCase {
+    var unNamedInput: NodeInput!
+    var namedInput: NodeInput!
+    var sampleValue: NSNumber!
+    var mockNode: _NodeInputTestMockNode!
+    
+    override func setUp() {
+        unNamedInput = NodeInput()
+        mockNode = _NodeInputTestMockNode()
+        sampleValue = NSNumber(42)
+        namedInput = NodeInput(withKey: "testKey", forNode: mockNode, withValidationBlock: { (value) -> Bool in
+            guard let _ = value as? NSNumber else {
+                return false
+            }
+            return true
+        })
+    }
+    
+    func test_init() {
+        let input = NodeInput()
+        XCTAssertNil(input.key)
+        XCTAssertNil(input.validationBlock)
+        XCTAssertNil(input.node)
+    }
+    
+    func test_initWithKey() {
+        let validationBlock: (_: AnyHashable?) -> Bool = { _ in return true }
+        let input = NodeInput(withKey: "testKey",
+                              forNode: mockNode,
+                              withValidationBlock: validationBlock)
+        XCTAssertEqual(input.key, "testKey")
+        
+        //NOTE: Not comparable in swift
+        //XCTAssertEqual(input.validationBlock!, validationBlock)
+        //XCTAssertEqual(input.node!, mockNode)
+    }
+    
+    // MARK: Validation
+    func test_nilValidationBlockResultsInValidValue() {
+        XCTAssertTrue(unNamedInput.valueIsValid(sampleValue))
+    }
+    
+    func test_nilValidationBlockResultsinValidValueWhenValueIsNil() {
+        XCTAssertTrue(unNamedInput.valueIsValid(nil))
+    }
+    
+    func test_validationBlockWithValidValue() {
+        let input = NodeInput(withKey: nil, forNode: nil) { (value) -> Bool in
+            guard let _ = value as? NSNumber else {
+                return false
+            }
+            return true
+        }
+        
+        XCTAssertTrue(input.valueIsValid(sampleValue))
+    }
+    
+    func test_validationBlockWithInvalidValue() {
+        let input = NodeInput(withKey: nil, forNode: nil) { (value) -> Bool in
+            guard let _ = value as? String else {
+                return false
+            }
+            return true
+        }
+        
+        XCTAssertFalse(input.valueIsValid(sampleValue))
+    }
+    
+    // MARK: Set value
+    func test_valueIsSet() {
+        let input = NodeInput(withKey: nil, forNode: nil) { (value) -> Bool in
+            guard let _ = value as? NSNumber else {
+                return false
+            }
+            return true
+        }
+        
+        input.value = sampleValue
+        XCTAssertEqual(input.value, sampleValue)
+    }
+    
+    func testvalueIsNotSetIfInvalid() {
+        let input = NodeInput(withKey: nil, forNode: nil) { (value) -> Bool in
+            guard let _ = value as? String else {
+                return false
+            }
+            return true
+        }
+        
+        input.value = sampleValue
+        XCTAssertNil(input.value)
+    }
+    
+    // MARK: Delegate
+    func test_delegateIsCalledWhenValueIsSet() {
+        namedInput.value = sampleValue
+        XCTAssertEqual(mockNode.delegateCallCount, 1)
+        XCTAssertEqual(mockNode.delegateCaller, namedInput)
+        XCTAssertEqual(mockNode.delegateValue, sampleValue)
+    }
+    
+    func test_delegateIsCalledWhenNilValueIsSet() {
+        let input = NodeInput(withKey: nil, forNode: mockNode)
+        input.value = sampleValue
+        input.value = nil
+        XCTAssertEqual(mockNode.delegateCallCount, 2)
+        XCTAssertEqual(mockNode.delegateCaller, input)
+        XCTAssertNil(mockNode.delegateValue)
+    }
+    
+    func test_delegateIsCalledOnceForSameArgumentMultipleTimes() {
+        namedInput.value = sampleValue
+        namedInput.value = sampleValue
+        namedInput.value = sampleValue
+        namedInput.value = sampleValue
+        XCTAssertEqual(mockNode.delegateCallCount, 1)
+        XCTAssertEqual(mockNode.delegateCaller, namedInput)
+        XCTAssertEqual(mockNode.delegateValue, sampleValue)
+    }
+    
+    func test_delegateIsNotCalledWhenValueIsNotValid() {
+        let input = NodeInput(withKey: nil, forNode: nil) { (value) -> Bool in
+            guard let _ = value as? String else {
+                return false
+            }
+            return true
+        }
+        input.value = sampleValue
+        XCTAssertEqual(mockNode.delegateCallCount, 0)
+        XCTAssertNil(mockNode.delegateCaller)
+        XCTAssertNil(mockNode.delegateValue)
+    }
+    
+    // MARK: Equatable and hashable sanity
+    func test_equalityOfSameInput() {
+        let input = NodeInput(withKey: nil, forNode: nil)
+        XCTAssertEqual(input, input)
+    }
+    
+    func test_equalityOfDifferentInputs() {
+        let input1 = NodeInput(withKey: nil, forNode: nil)
+        let input2 = NodeInput(withKey: nil, forNode: nil)
+        XCTAssertNotEqual(input1, input2)
+    }
+    
+    func test_hashableWithNilValues() {
+        let input1 = NodeInput(withKey: nil, forNode: nil)
+        let input2 = NodeInput(withKey: nil, forNode: nil)
+        
+        var testSet = Set<NodeInput>()
+        testSet.insert(input1)
+        testSet.insert(input2)
+        
+        XCTAssertEqual(testSet.count, 2)
+    }
+    
+    func test_hashableWithValues() {
+        let input1 = NodeInput(withKey: "TestKey", forNode: mockNode)
+        let input2 = NodeInput(withKey: "TestKey", forNode: mockNode)
+        
+        var testSet = Set<NodeInput>()
+        testSet.insert(input1)
+        testSet.insert(input2)
+        
+        XCTAssertEqual(testSet.count, 2)
+    }
+}

--- a/NodeGraphSwift-iosTests/NodeInputTests.swift
+++ b/NodeGraphSwift-iosTests/NodeInputTests.swift
@@ -10,12 +10,18 @@ import XCTest
 @testable import NodeGraphSwift_ios
 
 class _NodeInputTestMockNode: AbstractNode {
-    var delegateCallCount: NSInteger
+    var delegateCallCount: NSInteger = 0
     var delegateCaller: NodeInput? = nil
     var delegateValue: AnyHashable? = nil
     
     override init() {
         delegateCallCount = 0
+        
+        super.init()
+    }
+    
+    required init(from decoder: Decoder) throws {
+        fatalError("init(from:) has not been implemented")
     }
     
     override func nodeInputDidUpdateValue(_ nodeInput: NodeInput, value: AnyHashable?) {

--- a/NodeGraphSwift-iosTests/NodeOutputTests.swift
+++ b/NodeGraphSwift-iosTests/NodeOutputTests.swift
@@ -1,0 +1,122 @@
+//
+//  NodeOutputTests.swift
+//  NodeGraphSwift-iosTests
+//
+//  Created by Mikael Sundström on 2019-09-13.
+//  Copyright © 2019 NodeGraph. All rights reserved.
+//
+
+import XCTest
+@testable import NodeGraphSwift_ios
+
+class NodeOutputTests: XCTestCase {
+    
+    var unNamedOutput: NodeOutput!
+    var namedOutput: NodeOutput!
+    var sampleResult: NSNumber!
+
+    override func setUp() {
+        unNamedOutput = NodeOutput()
+        namedOutput = NodeOutput(withKey: "testKey")
+        sampleResult = NSNumber(value: 42)
+    }
+
+    //Mark: Inits
+    func test_init() {
+        let output = NodeOutput()
+        
+        XCTAssertNotNil(output.connections)
+        XCTAssertNil(output.key)
+    }
+    
+    func test_initWithKey() {
+        let output = NodeOutput(withKey: "testKey")
+        
+        XCTAssertNotNil(output.connections)
+        XCTAssertEqual(output.key, "testKey")
+    }
+    
+    //Mark: Connections
+    func test_addingConnection() {
+        let connection = NodeInput(withKey: nil, forNode: nil)
+        unNamedOutput.addConnection(nodeInput: connection)
+        
+        XCTAssertEqual(unNamedOutput.connections.count, 1)
+        XCTAssertEqual(connection, unNamedOutput.connections.anyObject)
+    }
+    
+    func test_addingSameConnectionTwiceOnlyStoreOne() {
+        let connection = NodeInput(withKey: nil, forNode: nil)
+        unNamedOutput.addConnection(nodeInput: connection)
+        unNamedOutput.addConnection(nodeInput: connection)
+        
+        XCTAssertEqual(unNamedOutput.connections.count, 1)
+        XCTAssertEqual(connection, unNamedOutput.connections.anyObject)
+    }
+    
+    func test_removingConnection() {
+        let connection = NodeInput(withKey: nil, forNode: nil)
+        unNamedOutput.addConnection(nodeInput: connection)
+        unNamedOutput.removeConnection(nodeInput: connection)
+        
+        XCTAssertEqual(unNamedOutput.connections.count, 0)
+    }
+    
+    func test_connectionIsRemovedWhenConnectionIsDeallocated() {
+        var connection: NodeInput? = NodeInput(withKey: nil, forNode: nil)
+        weak var weakConnection = connection
+        unNamedOutput.addConnection(nodeInput: connection!)
+        XCTAssertEqual(unNamedOutput.connections.count, 1)
+        
+        connection = nil
+        
+        XCTAssertNil(weakConnection, "Something wrong with test, are you referencing the connection that accidentally stops it from being deallocated when connection is set to nil?")
+        
+        XCTAssertEqual(unNamedOutput.connections.allObjects.count, 0)
+        XCTAssertNil(unNamedOutput.connections.anyObject)
+        
+    }
+    
+    //MARK: Send results
+    func test_sendingResultToNoConnectionDoesNotCrash() {
+        unNamedOutput.send(result: nil)
+    }
+    
+    func test_sendingResultToNoConnectionsDoesNotCrash() {
+        unNamedOutput.send(result: sampleResult)
+    }
+    
+    func test_sendingResultToSingleConnection() {
+        let connection = NodeInput(withKey: nil, forNode: nil)
+        unNamedOutput.addConnection(nodeInput: connection)
+        unNamedOutput.send(result: sampleResult)
+        XCTAssertEqual(connection.value, sampleResult)
+    }
+    
+    func test_sendingNilResultToSingleConnection() {
+        let connection = NodeInput(withKey: nil, forNode: nil)
+        unNamedOutput.addConnection(nodeInput: connection)
+        unNamedOutput.send(result: nil)
+        XCTAssertNil(connection.value)
+    }
+    
+    func test_sendingResultToMultipleConnections() {
+        let connection1 = NodeInput(withKey: nil, forNode: nil)
+        let connection2 = NodeInput(withKey: nil, forNode: nil)
+        unNamedOutput.addConnection(nodeInput: connection1)
+        unNamedOutput.addConnection(nodeInput: connection2)
+        unNamedOutput.send(result: sampleResult)
+        XCTAssertEqual(connection1.value, sampleResult)
+        XCTAssertEqual(connection2.value, sampleResult)
+    }
+    
+    func test_sendingNilResultToMultipleConnections() {
+        let connection1 = NodeInput(withKey: nil, forNode: nil)
+        let connection2 = NodeInput(withKey: nil, forNode: nil)
+        unNamedOutput.addConnection(nodeInput: connection1)
+        unNamedOutput.addConnection(nodeInput: connection2)
+        unNamedOutput.send(result: nil)
+        XCTAssertNil(connection1.value)
+        XCTAssertNil(connection2.value)
+    }
+}

--- a/NodeGraphSwift-iosTests/SerializableNodeTests.swift
+++ b/NodeGraphSwift-iosTests/SerializableNodeTests.swift
@@ -1,0 +1,52 @@
+//
+//  SerializableNodeTests.swift
+//  NodeGraphSwift-iosTests
+//
+//  Created by Mikael Sundström on 2019-10-03.
+//  Copyright © 2019 NodeGraph. All rights reserved.
+//
+
+import XCTest
+@testable import NodeGraphSwift_ios
+
+class _SerializableTestNode: AbstractNode {
+    override init() {
+        
+        super.init()
+
+        let output = NodeOutput(withKey: "TestOutput")
+        let input = NodeInput(withKey: "TestInput", forNode: self)
+        
+        inputs.insert(input)
+        outputs.insert(output)
+        
+    }
+    
+    required init(from decoder: Decoder) throws {
+        fatalError("init(from:) has not been implemented")
+    }
+}
+
+class SerializableNodeTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        let node = _SerializableTestNode()
+        node.nodeName = "_SerializableTestNode --- asd"
+        node.nodeDescription = "_SerializableTestNode description"
+        
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = .prettyPrinted
+        
+        let jsonData = try! jsonEncoder.encode(node)
+        let jsonString = String(data: jsonData, encoding: .utf8)
+        print(jsonString!)
+    }
+}


### PR DESCRIPTION
Adds a Swift target.

Known issues:
- [x] - `Bad access` crash when running `test_directProcessingPerformance`
- [ ] - Timeout when running `test_deferredProcessingPerformance`

Missing functionality:
- [ ] - Seralize: 
   - [ ] - Node
   - [ ] - Input
   - [ ] - Output
- [ ] - Graph node
- [ ] - Custom input types
- [ ] - Custom output types

